### PR TITLE
Only apply change to attribute if needed (idempotent)

### DIFF
--- a/xml
+++ b/xml
@@ -157,12 +157,15 @@ def add_target_children(tree, xpath, children, module):
         finish(tree, xpath, module)
 
 def set_target_attribute(tree, xpath, attribute, value, module):
+    changed = False
+
     if is_node(tree, xpath):
         for element in tree.xpath(xpath):
-            if not module.check_mode: element.set(attribute, value)
-            finish(tree, xpath, module, changed=True)
-        else:
-            finish(tree, xpath, module, changed=True)
+            if (element.get(attribute) != value):
+                if not module.check_mode: element.set(attribute, value)
+                changed = True
+
+    finish(tree, xpath, module, changed=changed)
 
 def child_to_element(child, module):
     ch_type = type(child)


### PR DESCRIPTION
Previous version always applied change when setting an attribute,
independently if the attribute was already set to the desired value.
This patch now check the existing value before applying change, and
will apply the change only if needed. This is particularly useful when
running in check to determine if changes to a file are needed.
