### PR TITLE
Added the 'namespace' parameter to allow operations no namespaced XML

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -40,6 +40,12 @@ options:
     required: false
     default: /
     choices: []
+  namespaces:
+    description:
+      - The namespace prefix:uri mapping for the XPath expression. Needs to be a *map*, not a list of items.
+    required: false
+    default: null
+    choices: []
   ensure:
     description:
       - Set or remove an xpath selection (node(s), attribute(s))
@@ -99,72 +105,72 @@ except:
 import lxml
 import os
 
-def print_match(tree, xpath, module):
-    match = tree.xpath(xpath)
+def print_match(tree, xpath, namespaces, module):
+    match = tree.xpath(xpath, namespaces=namespaces)
     match_xpaths = []
     for m in match:
         match_xpaths.append(tree.getpath(m))
     match_str = json.dumps(match_xpaths)
     msg = "selector '%s' match: %s" % (xpath, match_str)
-    finish(tree, xpath, module, changed=False, msg=msg)
+    finish(tree, xpath, namespaces, module, changed=False, msg=msg)
 
-def count(tree, xpath, module):
+def count(tree, xpath, namespaces, module):
     """ Return the count of nodes matching the xpath """
-    hits = tree.xpath("count(/%s)" % xpath)
-    finish(tree, xpath, module, changed=False, msg=int(hits), hitcount=int(hits))
+    hits = tree.xpath("count(/%s)" % xpath, namespaces=namespaces)
+    finish(tree, xpath, namespaces, module, changed=False, msg=int(hits), hitcount=int(hits))
 
-def is_node(tree, xpath):
+def is_node(tree, xpath, namespaces):
     """ Test if a given xpath matches anything and if that match is a node.
 
     For now we just assume you're only searching for one specific thing."""
-    if xpath_matches(tree, xpath):
+    if xpath_matches(tree, xpath, namespaces):
         # OK, it found something
-        match = tree.xpath(xpath)
+        match = tree.xpath(xpath, namespaces=namespaces)
         if type(match[0]) == lxml.etree._Element:
             return True
 
     return False
 
-def is_attribute(tree, xpath):
+def is_attribute(tree, xpath, namespaces):
     """ Test if a given xpath matches and that match is an attribute
 
 An xpath attribute search will only match one item"""
-    if xpath_matches(tree, xpath):
-        match = tree.xpath(xpath)
+    if xpath_matches(tree, xpath, namespaces):
+        match = tree.xpath(xpath, namespaces=namespaces)
         if type(match[0]) == lxml.etree._ElementStringResult:
             return True
     return False
 
-def xpath_matches(tree, xpath):
+def xpath_matches(tree, xpath, namespaces):
     """ Test if a node exists """
-    if tree.xpath(xpath):
+    if tree.xpath(xpath, namespaces=namespaces):
         return True
     else:
         return False
 
-def delete_xpath_target(tree, xpath, module):
+def delete_xpath_target(tree, xpath, namespaces, module):
     """ Delete an attribute or element from a tree """
     try:
-        for result in tree.xpath(xpath):
+        for result in tree.xpath(xpath, namespaces=namespaces):
             if not module.check_mode:
                 # Get the xpath for this result
-                if is_attribute(tree, xpath):
+                if is_attribute(tree, xpath, namespaces):
                     # Delete an attribute
                     parent = result.getparent()
                     # Pop this attribute match out of the parent
                     # node's 'attrib' dict by using this match's
                     # 'attrname' attribute for the key
                     parent.attrib.pop(result.attrname)
-                elif is_node(tree, xpath):
+                elif is_node(tree, xpath, namespaces):
                     # Delete an element
                     result.getparent().remove(result)
     except Exception, e:
         abort("Couldn't delete xpath target: %s (%s)" % (xpath, str(e)), module)
     else:
-        finish(tree, xpath, module, changed=True)
+        finish(tree, xpath, namespaces, module, changed=True)
 
-def set_target_children(tree, xpath, children, module):
-    matches = tree.xpath(xpath)
+def set_target_children(tree, xpath, namespaces, children, module):
+    matches = tree.xpath(xpath, namespaces=namespaces)
 
     # Create a list of our new children
     children = children_to_nodes(children=children, module=module)
@@ -182,32 +188,35 @@ def set_target_children(tree, xpath, children, module):
         changed = True
 
     # Write it out
-    finish(tree, xpath, module, changed=changed)
+    finish(tree, xpath, namespaces, module, changed=changed)
 
-def add_target_children(tree, xpath, children, module):
-    if is_node(tree, xpath):
+def add_target_children(tree, xpath, namespaces, children, module):
+    if is_node(tree, xpath, namespaces):
         new_kids = children_to_nodes(children, module)
-        for node in tree.xpath(xpath):
+        for node in tree.xpath(xpath, namespaces=namespaces):
             if not module.check_mode: node.extend(new_kids)
-        finish(tree, xpath, module, changed=True)
+        finish(tree, xpath, namespaces, module, changed=True)
     else:
-        finish(tree, xpath, module)
+        finish(tree, xpath, namespaces, module)
 
-def set_target(tree, xpath, attribute, value, module):
+def set_target(tree, xpath, namespaces, attribute, value, module):
     changed = False
 
-    if not is_node(tree, xpath):
+    if not is_node(tree, xpath, namespaces):
         abort("Xpath " + xpath + " does not reference a node!", module)
 
-    for element in tree.xpath(xpath):
+    for element in tree.xpath(xpath, namespaces=namespaces):
         if not attribute:
             changed = (element.text != value)
             if not module.check_mode and changed: element.text = value
         else:
             changed = (element.get(attribute) != value)
+            if ":" in attribute:
+                attr_ns, attr_name = attribute.split(":")
+                attribute = "{{{0}}}{1}".format(namespaces[attr_ns], attr_name)
             if not module.check_mode and changed: element.set(attribute, value)
 
-    finish(tree, xpath, module, changed)
+    finish(tree, xpath, namespaces, module, changed)
 
 def child_to_element(child, module):
     ch_type = type(child)
@@ -234,11 +243,11 @@ def children_to_nodes(children=[], module=None):
 def abort(msg, m):
     m.fail_json(msg=msg)
 
-def finish(tree, xpath, m, changed=False, msg="", hitcount=0):
+def finish(tree, xpath, namespaces, m, changed=False, msg="", hitcount=0):
     if changed:
         xml_file = os.path.expanduser(m.params['file'])
         tree.write(xml_file, xml_declaration=True, encoding='UTF-8', pretty_print=m.params['pretty_print'])
-    m.exit_json(changed=changed,actions={"xpath": xpath, "ensure": m.params['ensure']}, msg=msg, count=hitcount)
+    m.exit_json(changed=changed,actions={"xpath": xpath, "namespaces": namespaces, "ensure": m.params['ensure']}, msg=msg, count=hitcount)
 
 def main():
     module = AnsibleModule(
@@ -246,6 +255,7 @@ def main():
             file=dict(required=False, default=None),
             xmlstring=dict(required=False, default=None),
             xpath=dict(required=False, default='/'),
+            namespaces=dict(required=False, default={}),
             ensure=dict(required=False, default='present', choices=['absent', 'present']),
             value=dict(required=False, default=None),
             attribute=dict(required=False, default=None),
@@ -267,6 +277,7 @@ def main():
     xml_file = os.path.expanduser(module.params['file'])
     xml_string = module.params['xmlstring']
     xpath = module.params['xpath']
+    namespaces = module.params['namespaces']
     ensure = module.params['ensure']
     value = module.params['value']
     attribute = module.params['attribute']
@@ -296,10 +307,10 @@ def main():
             str(e))
 
     if module.params['print_match']:
-        print_match(x, xpath, module)
+        print_match(x, xpath, namespaces, module)
 
     if module.params['count']:
-        count(x, xpath, module)
+        count(x, xpath, namespaces, module)
 
     # module.fail_json(msg="OK. Well, etree parsed the xml file...")
 
@@ -310,7 +321,7 @@ def main():
     # Ensure:
     if ensure == 'absent':
         # - absent: delete xpath target
-        delete_xpath_target(x, xpath, module)
+        delete_xpath_target(x, xpath, namespaces, module)
         # Exit
     # - present: carry on
 
@@ -326,13 +337,13 @@ def main():
     # set_children set?
     # Yes: Set children of target
     if module.params['set_children']:
-        set_target_children(x, xpath, set_children, module)
+        set_target_children(x, xpath, namespaces, set_children, module)
 
     ##################################################################
     # add_children set?
     # Yes: Add children to target
     if module.params['add_children']:
-        add_target_children(x, xpath, add_children, module)
+        add_target_children(x, xpath, namespaces, add_children, module)
 
     # No?: Carry on
 
@@ -340,7 +351,7 @@ def main():
     # Is the xpath target an attribute selector?
     # Yes: Set the attribute, exit
     if module.params['value']:
-        set_target(x, xpath, attribute, value, module)
+        set_target(x, xpath, namespaces, attribute, value, module)
 
 ######################################################################
 from ansible.module_utils.basic import *

--- a/tests/fixtures/ansible-xml-namespaced-beers.xml
+++ b/tests/fixtures/ansible-xml-namespaced-beers.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="true">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-add-namespaced-children-elements.xml
+++ b/tests/results/test-add-namespaced-children-elements.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  <beer>Old Rasputin</beer></beers>
+  <rating xmlns="http://test.rating" attr:subjective="true">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-remove-namespaced-attribute.xml
+++ b/tests/results/test-remove-namespaced-attribute.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-remove-namespaced-element.xml
+++ b/tests/results/test-remove-namespaced-element.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-set-namespaced-attribute-value.xml
+++ b/tests/results/test-set-namespaced-attribute-value.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="false">10</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-set-namespaced-element-value.xml
+++ b/tests/results/test-set-namespaced-element-value.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business xmlns="http://test.business" xmlns:attr="http://test.attribute" type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers xmlns="http://test.beers">
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating xmlns="http://test.rating" attr:subjective="true">11</rating>
+  <website xmlns="http://test.website">
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/test-add-namespaced-children-elements.yml
+++ b/tests/test-add-namespaced-children-elements.yml
@@ -1,0 +1,16 @@
+---
+  - name: Setup test fixture
+    command: cp fixtures/ansible-xml-namespaced-beers.xml /tmp/ansible-xml-namespaced-beers.xml
+
+  - name: Add namespaced child element
+    xml:
+      file: /tmp/ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/ber:beers
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+      add_children:
+        - beer: "Old Rasputin"
+
+  - name: Test expected result
+    command: diff results/test-add-namespaced-children-elements.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/tests/test-remove-namespaced-attribute.yml
+++ b/tests/test-remove-namespaced-attribute.yml
@@ -1,0 +1,18 @@
+---
+  - name: Setup test fixture
+    command: cp fixtures/ansible-xml-namespaced-beers.xml /tmp/ansible-xml-namespaced-beers.xml
+
+  - name: Remove namespaced '/bus:business/rat:rating/@attr:subjective'
+    xml:
+      file: /tmp/ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/rat:rating/@attr:subjective
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      ensure: absent
+
+
+  - name: Test expected result
+    command: diff results/test-remove-namespaced-attribute.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/tests/test-remove-namespaced-element.yml
+++ b/tests/test-remove-namespaced-element.yml
@@ -1,0 +1,17 @@
+---
+  - name: Setup test fixture
+    command: cp fixtures/ansible-xml-namespaced-beers.xml /tmp/ansible-xml-namespaced-beers.xml
+
+  - name: Remove namespaced '/bus:business/rat:rating'
+    xml:
+      file: /tmp/ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/rat:rating
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      ensure: absent
+
+  - name: Test expected result
+    command: diff results/test-remove-element.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/tests/test-set-namespaced-attribute-value.yml
+++ b/tests/test-set-namespaced-attribute-value.yml
@@ -1,0 +1,19 @@
+---
+  - name: Setup test fixture
+    command: cp fixtures/ansible-xml-namespaced-beers.xml /tmp/ansible-xml-namespaced-beers.xml
+
+  - name: Set namespaced '/bus:business/rat:rating/@attr:subjective' to 'false'
+    xml:
+      file: /tmp/ansible-xml-namespaced-beers.xml
+      xpath: /bus:business/rat:rating
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      attribute: attr:subjective
+      value: "false"
+
+  - name: Test expected result
+    command: diff results/test-set-namespaced-attribute-value.xml /tmp/ansible-xml-namespaced-beers.xml
+    changed_when: False

--- a/tests/test-set-namespaced-element-value.yml
+++ b/tests/test-set-namespaced-element-value.yml
@@ -1,0 +1,38 @@
+---
+  - name: Setup test fixture
+    command: cp fixtures/ansible-xml-namespaced-beers.xml /tmp/ansible-xml-namespaced-beers.xml
+
+  - name: Set namespaced '/bus:business/rat:rating' to '11'
+    xml:
+      file: /tmp/ansible-xml-namespaced-beers.xml
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      xpath: /bus:business/rat:rating
+      value: "11"
+    register: set_element_first_run
+
+  - name: Set namespaced '/bus:business/rat:rating' to '11' again
+    xml:
+      file: /tmp/ansible-xml-namespaced-beers.xml
+      namespaces:
+        bus: http://test.business
+        ber: http://test.beers
+        rat: http://test.rating
+        attr: http://test.attribute
+      xpath: /bus:business/rat:rating
+      value: "11"
+    register: set_element_second_run
+  - name: Test expected result
+    command: diff results/test-set-namespaced-element-value.xml /tmp/ansible-xml-namespaced-beers.xml
+    changed_when: False
+
+
+  - name: Test registered 'changed' on run 1 and unchanged on run 2
+    assert:
+      that:
+        - set_element_first_run.changed
+        - not set_element_second_run.changed
+...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -13,8 +13,12 @@
       - include: test-count.yml
       - include: test-mutually-exclusive-attributes.yml
       # @todo removal of attributes is broken?
-#      - include: test-remove-attribute.yml
+      - include: test-remove-attribute.yml
       - include: test-remove-element.yml
       - include: test-set-attribute-value.yml
       - include: test-set-element-value.yml
       - include: test-pretty-print.yml
+      - include: test-add-namespaced-children-elements.yml
+      - include: test-remove-namespaced-attribute.yml
+      - include: test-set-namespaced-attribute-value.yml
+      - include: test-set-namespaced-element-value.yml


### PR DESCRIPTION
Being able to work with namespaced XML is quite important if you need to work with config files such as the ones in JBoss, for example. This patch adds an attribute that allows namespace prefix mapping. I created a couple or relevant tasks as well.