### PR TITLE
Fix results for add-children-with-attributes test

### DIFF
--- a/tests/results/test-add-children-with-attributes.xml
+++ b/tests/results/test-add-children-with-attributes.xml
@@ -5,7 +5,7 @@
     <beer>Rochefort 10</beer>
     <beer>St. Bernardus Abbot 12</beer>
     <beer>Schlitz</beer>
-  <beer type="light" name="Ansible Brew"/></beers>
+  <beer name="Ansible Brew" type="light"/></beers>
   <rating subjective="true">10</rating>
   <website>
     <mobilefriendly/>


### PR DESCRIPTION
When I run the tests these attributes appear in a different order, does the same happen for others?