### PR TITLE
Add support of unicode symbols

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -291,6 +291,20 @@ def finish(tree, xpath, namespaces, m, changed=False, msg="", hitcount=0, matche
         tree.write(xml_file, xml_declaration=True, encoding='UTF-8', pretty_print=m.params['pretty_print'])
     m.exit_json(changed=changed,actions={"xpath": xpath, "namespaces": namespaces, "ensure": m.params['ensure']}, msg=msg, count=hitcount, matches=matches)
 
+def decode(value):
+    # Convert value to unicode to use with lxml
+    if not value or isinstance(value, unicode):
+        return value
+    elif isinstance(value, str):
+        return value.decode('utf-8')
+    elif isinstance(value, list):
+        return [decode(v) for v in value]
+    elif isinstance(value, dict):
+        return dict((key, decode(val)) for key, val in value.iteritems())
+    else:
+        raise AttributeError('Undecodable value: type=%s, value=%s' %
+                             (type(value), value))
+
 def main():
     module = AnsibleModule(
         argument_spec=dict(
@@ -325,10 +339,10 @@ def main():
     xpath = module.params['xpath']
     namespaces = module.params['namespaces']
     ensure = module.params['ensure']
-    value = module.params['value']
+    value = decode(module.params['value'])
     attribute = module.params['attribute']
-    set_children = module.params['set_children']
-    add_children = module.params['add_children']
+    set_children = decode(module.params['set_children'])
+    add_children = decode(module.params['add_children'])
     pretty_print = module.params['pretty_print']
     content = module.params['content']
 

--- a/tests/fixtures/ansible-xml-beers-unicode.xml
+++ b/tests/fixtures/ansible-xml-beers-unicode.xml
@@ -1,0 +1,13 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Толстый бар</name>
+  <beers>
+    <beer>Окское</beer>
+    <beer>Невское</beer>
+  </beers>
+  <rating subjective="да">десять</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tolstyybar.com</address>
+  </website>
+</business>

--- a/tests/results/test-add-children-elements-unicode.xml
+++ b/tests/results/test-add-children-elements-unicode.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  <beer>Окское</beer></beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-add-children-with-attributes-unicode.xml
+++ b/tests/results/test-add-children-with-attributes-unicode.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  <beer name="Окское" type="экстра"/></beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-set-attribute-value-unicode.xml
+++ b/tests/results/test-set-attribute-value-unicode.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="нет">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-set-children-elements-unicode.xml
+++ b/tests/results/test-set-children-elements-unicode.xml
@@ -1,0 +1,11 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Окское</beer><beer>Невское</beer></beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+</business>

--- a/tests/results/test-set-element-value-unicode.xml
+++ b/tests/results/test-set-element-value-unicode.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">пять</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+  </website>
+<rating>пять</rating></business>

--- a/tests/test-add-children-elements-unicode.yml
+++ b/tests/test-add-children-elements-unicode.yml
@@ -1,0 +1,13 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+
+  - name: Add child element
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children:
+        - beer: "Окское"
+
+  - name: Test expected result
+    command: diff results/test-add-children-elements-unicode.xml /tmp/ansible-xml-beers.xml

--- a/tests/test-add-children-with-attributes-unicode.yml
+++ b/tests/test-add-children-with-attributes-unicode.yml
@@ -1,0 +1,15 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+
+  - name: Add child element
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/beers
+      add_children:
+          - beer:
+              name: Окское
+              type: экстра
+
+  - name: Test expected result
+    command: diff results/test-add-children-with-attributes-unicode.xml /tmp/ansible-xml-beers.xml

--- a/tests/test-count-unicode.yml
+++ b/tests/test-count-unicode.yml
@@ -1,0 +1,11 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers-unicode.xml dest=/tmp/ansible-xml-beers-unicode.xml
+
+  - name: Count child element
+    xml:
+      file: /tmp/ansible-xml-beers-unicode.xml
+      xpath: /business/beers/beer
+      count: true
+    register: beers
+    failed_when: beers.count != 2

--- a/tests/test-get-element-content-unicode.yml
+++ b/tests/test-get-element-content-unicode.yml
@@ -1,0 +1,19 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers-unicode.xml dest=/tmp/ansible-xml-beers-unicode.xml
+
+  - name: Get element attributes
+    xml:
+      file: /tmp/ansible-xml-beers-unicode.xml
+      xpath: /business/rating
+      content: 'attribute'
+    register: get_element_attribute
+    failed_when: get_element_attribute.matches[0]['rating'] is not defined or get_element_attribute.matches[0]['rating']['subjective'] != 'да'
+
+  - name: Get element text
+    xml:
+      file: /tmp/ansible-xml-beers-unicode.xml
+      xpath: /business/rating
+      content: 'text'
+    register: get_element_text
+    failed_when: get_element_text.matches[0]['rating'] != 'десять'

--- a/tests/test-set-attribute-value-unicode.yml
+++ b/tests/test-set-attribute-value-unicode.yml
@@ -1,0 +1,14 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+
+  - name: Set '/business/rating/@subjective' to 'нет'
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/rating
+      attribute: subjective
+      value: "нет"
+
+  - name: Test expected result
+    command: diff results/test-set-attribute-value-unicode.xml /tmp/ansible-xml-beers.xml
+    changed_when: False

--- a/tests/test-set-children-elements-unicode.yml
+++ b/tests/test-set-children-elements-unicode.yml
@@ -1,0 +1,26 @@
+---
+  - name: Setup test fixture
+    command: cp fixtures/ansible-xml-beers.xml /tmp/ansible-xml-beers.xml
+
+  - name: Set child elements
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children:
+        - beer: "Окское"
+        - beer: "Невское"
+
+  - name: Test expected result
+    command: diff results/test-set-children-elements-unicode.xml /tmp/ansible-xml-beers.xml
+
+  - name: Set child elements
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/beers
+      set_children:
+        - beer: "Окское"
+        - beer: "Невское"
+    register: set_children_again
+
+  - fail: msg="Setting children is not idempotent!"
+    when: set_children_again.changed

--- a/tests/test-set-element-value-unicode.yml
+++ b/tests/test-set-element-value-unicode.yml
@@ -1,0 +1,35 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+
+  - name: Add 2nd '/business/rating' with value 'пять'
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business
+      add_children:
+        - rating: "пять"
+
+  - name: Set '/business/rating' to 'пять'
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/rating
+      value: "пять"
+    register: set_element_first_run
+
+  - name: Set '/business/rating' to 'false'... again
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/rating
+      value: "пять"
+    register: set_element_second_run
+
+  - name: Test expected result
+    command: diff results/test-set-element-value-unicode.xml /tmp/ansible-xml-beers.xml
+    changed_when: False
+
+  - name: Test registered 'changed' on run 1 and unchanged on run 2
+    assert:
+      that:
+        - set_element_first_run.changed
+        - not set_element_second_run.changed
+...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -23,4 +23,13 @@
     - include: test-set-namespaced-attribute-value.yml
     - include: test-set-namespaced-element-value.yml
     - include: test-get-element-content.yml
+
+    # Unicode tests
+    - include: test-add-children-elements-unicode.yml
+    - include: test-add-children-with-attributes-unicode.yml
+    - include: test-set-attribute-value-unicode.yml
+    - include: test-count-unicode.yml
+    - include: test-get-element-content.yml
+    - include: test-set-children-elements-unicode.yml
+    - include: test-set-element-value-unicode.yml
 ...


### PR DESCRIPTION
`lxml` library works only with unicode strings. It is impossible to use base python `str` with cyrillic symbols inside `lxml`:

```
ValueError: All strings must be XML compatible: Unicode or ASCII, no NULL bytes or control characters
```

Current fix adds decoding value parameter if it is not unicode.