### PR TITLE
Fix #44 Ansible 2.0.0.2 related errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ python: "2.7"
 before_install:
   # install libxml dependency binaries
   - sudo apt-get install libxml2 libxml2-dev libxslt-dev python-dev
-  
+
   # build/install current version of libxml
   - sudo CFLAGS="-O0" pip install lxml --upgrade
-  
+
   # Make sure everything's up to date.
   - sudo apt-get update -qq
 
@@ -20,9 +20,12 @@ script:
   # log version of Ansible
   - ansible --version
 
+  # change directory to test playbook
+  - cd tests
+
   # Check the role/playbook's syntax.
-  - ansible-playbook -i tests/inventory tests/test.yml --syntax-check
+  - ansible-playbook -i inventory test.yml --syntax-check --list-tasks -vvvv
 
   # Run the miscellaneous tests.
-  - "ansible-playbook -i tests/inventory tests/test.yml"
+  - "ansible-playbook -i inventory test.yml"
 ...

--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,2 +1,0 @@
-[defaults]
-roles_path = ../

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -6,4 +6,4 @@ galaxy_info:
   categories:
     - files
 dependencies: []
-version: 0.3.1
+...


### PR DESCRIPTION
- Directory structure uses relative path from where command is run vs. where playbook lives now.
- Version no longer valid in the meta file.
- Was breaking Travis CI, so couldn't assess PRs.

Resolves https://github.com/cmprescott/ansible-xml/issues/44