### PR TITLE
Checking value for None, not just false

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -402,7 +402,7 @@ def main():
     ##################################################################
     # Is the xpath target an attribute selector?
     # Yes: Set the attribute, exit
-    if module.params['value']:
+    if module.params['value'] is not None:
         set_target(x, xpath, namespaces, attribute, value, module)
 
 ######################################################################


### PR DESCRIPTION
I suggest checking *value* for **None**, because we assign **None** by default in line 302. This way the module doesn't crash with parse error if you set *value* to empty string, e.g.:
`xml: file=/var/lib/jenkins/config.xml xpath=/hudson/label value=""`

This syntax is different from:
`xml: file=/var/lib/jenkins/config.xml xpath=/hudson/label/* state=absent`
because the former allows using *with_dict* iterator for many values at once.