### PR TITLE
Empty value fix

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -416,7 +416,7 @@ def main():
     ##################################################################
     # Is the xpath target an attribute selector?
     # Yes: Set the attribute, exit
-    if module.params['value']:
+    if module.params['value'] is not None:
         set_target(x, xpath, namespaces, attribute, value, module)
 
 ######################################################################

--- a/tests/results/test-set-element-value-empty.xml
+++ b/tests/results/test-set-element-value-empty.xml
@@ -1,0 +1,14 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address></address>
+  </website>
+</business>

--- a/tests/test-set-element-value-empty.yml
+++ b/tests/test-set-element-value-empty.yml
@@ -1,0 +1,12 @@
+---
+  - name: Setup test fixture
+    copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+
+  - name: Set /business/website/address to empty string.
+    xml:
+      file: /tmp/ansible-xml-beers.xml
+      xpath: /business/website/address
+      value: ''
+
+  - name: Test expected result
+    command: diff results/test-set-element-value-empty.xml /tmp/ansible-xml-beers.xml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -17,6 +17,7 @@
     - include: test-set-attribute-value.yml
     - include: test-set-children-elements.yml
     - include: test-set-element-value.yml
+    - include: test-set-element-value-empty.yml
     - include: test-pretty-print.yml
     - include: test-add-namespaced-children-elements.yml
     - include: test-remove-namespaced-attribute.yml


### PR DESCRIPTION
This is a copy of the previous pull request #49, which suggests testing the value using None instead of testing truthiness.  This allows you to set value to the empty string, useful for dictionary lookups.  

Included is a unit test.