### PR TITLE
Fixed test to fail if module fails and not ignore errors

### DIFF
--- a/tests/test-mutually-exclusive-attributes.yml
+++ b/tests/test-mutually-exclusive-attributes.yml
@@ -9,5 +9,5 @@
             - child01
             - child02
         value: conflict!
-    # @todo this is exercised but not really tested
-    ignore_errors: true
+    register: module_output
+    failed_when: "module_output.failed == 'false'"


### PR DESCRIPTION
Previously, this test ignored the module error output.  It will now fail correctly in this case, and succeed otherwise.  This eliminates the last of the red in your test.

I think this is what was meant by errors in [this stackoverflow question](http://stackoverflow.com/questions/30960904/ansible-xml-manipulation-similar-to-lineinfile)