### PR TITLE
Implement implicit element creation via XPath (fixes: #81, #37)

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -230,20 +230,30 @@ def add_target_children(module, tree, xpath, namespaces, children, type):
     else:
         finish(module, tree, xpath, namespaces)
 
-_re_splitSimpleLast = re.compile("^(.*)/([a-zA-Z][a-zA-Z0-9_]*)$")
+_ident = "[a-zA-Z-][a-zA-Z0-9_-]*"
+_nsIdent = _ident +"|"+_ident+":"+_ident
+_re_splitSimpleLast = re.compile("^(.*)/("+_nsIdent+")$")
+_re_splitSimpleAttrLast = re.compile("^(.*)/(@(?:"+_nsIdent+"))$")
 def split_xpath_last(xpath):
     """split an XPath of the form /foo/bar/baz into /foo/bar and baz"""
     xpath = xpath.strip()
     m = _re_splitSimpleLast.match(xpath)
     if m:
         return (m.group(1), [(m.group(2), None)]) # requesting an attribute to exist
+    m = _re_splitSimpleAttrLast.match(xpath)
+    if m:
+        return (m.group(1), [(m.group(2), None)]) # requesting an attribute to exist
 
-    return (xpath, None)
+    return (xpath, [])
 
 def check_or_make_target(module, tree, xpath, namespaces):
+    (inner_xpath, changes) = split_xpath_last(xpath)
+    if (inner_xpath == xpath) or (changes == None):
+        abort(module, "Can't process Xpath " + xpath + " in order to spawn nodes! tree is " + etree.tostring(tree, pretty_print=True))
+        return False
+
     changed = False
 
-    (inner_xpath, changes) = split_xpath_last(xpath)
     if not is_node(tree, inner_xpath, namespaces):
         changed = check_or_make_target(module, tree, inner_xpath, namespaces)
 
@@ -256,14 +266,36 @@ def check_or_make_target(module, tree, xpath, namespaces):
                     if not module.check_mode: node.extend(new_kids)
                     changed = True
                 #abort(module, "now tree=" + etree.tostring(tree, pretty_print=True))
+            elif eoa[0] == '@':
+                attribute = eoa[1:]
+
+                if ":" in attribute:
+                    attr_ns, attr_name = attribute.split(":")
+                    attribute = "{{{0}}}{1}".format(namespaces[attr_ns], attr_name)
+
+                for element in tree.xpath(inner_xpath, namespaces=namespaces):
+                    changing = (not element.attrib.has_key(attribute)) or (element.attrib.get(attribute) != eoa_value)
+
+                    if not module.check_mode and changing:
+                        changed = changed or changing
+                        if eoa_value is None:
+                            value = ""
+                        else:
+                            value = eoa_value
+                        element.attrib[attribute] = value
+
+                    #abort(module, "arf "+xpath+"  changing="+str(changing)+"  as curval="+str(element.get(attribute))+" changed tree=" + etree.tostring(tree, pretty_print=True))
+
+
             else:
                 abort(module, "NTO changed tree=" + etree.tostring(tree, pretty_print=True))
+
     return changed
 
 
 def ensure_xpath_exists(module, tree, xpath, namespaces):
     changed = False
-    
+
     if not is_node(tree, xpath, namespaces):
         changed = check_or_make_target(module, tree, xpath, namespaces)
 
@@ -276,7 +308,7 @@ def set_target_inner(module, tree, xpath, namespaces, attribute, value):
         changed = check_or_make_target(module, tree, xpath, namespaces)
 
     if not is_node(tree, xpath, namespaces):
-        abort(module, "Xpath " + xpath + " does not reference a node! tree is " + str(tree))
+        abort(module, "Xpath " + xpath + " does not reference a node! tree is " + etree.tostring(tree, pretty_print=True))
 
     for element in tree.xpath(xpath, namespaces=namespaces):
         if not attribute:

--- a/library/xml
+++ b/library/xml
@@ -120,6 +120,7 @@ except:
     import simplejson as json
 import lxml
 import os
+import re
 
 def print_match(module, tree, xpath, namespaces):
     match = tree.xpath(xpath, namespaces=namespaces)
@@ -185,7 +186,7 @@ def delete_xpath_target(module, tree, xpath, namespaces):
     else:
         finish(module, tree, xpath, namespaces, changed=True)
 
-def set_target_children(module, tree, xpath, namespaces, children, type):
+def set_target_children_inner(module, tree, xpath, namespaces, children, type):
     matches = tree.xpath(xpath, namespaces=namespaces)
 
     # Create a list of our new children
@@ -213,6 +214,10 @@ def set_target_children(module, tree, xpath, namespaces, children, type):
             replace_children_of(match)
             changed = True
 
+    return changed
+
+def set_target_children(module, tree, xpath, namespaces, children, type):
+    changed = set_target_children_inner(module, tree, xpath, namespaces, children, type)
     # Write it out
     finish(module, tree, xpath, namespaces, changed=changed)
 
@@ -225,11 +230,53 @@ def add_target_children(module, tree, xpath, namespaces, children, type):
     else:
         finish(module, tree, xpath, namespaces)
 
-def set_target(module, tree, xpath, namespaces, attribute, value):
+_re_splitSimpleLast = re.compile("^(.*)/([a-zA-Z][a-zA-Z0-9_]*)$")
+def split_xpath_last(xpath):
+    """split an XPath of the form /foo/bar/baz into /foo/bar and baz"""
+    xpath = xpath.strip()
+    m = _re_splitSimpleLast.match(xpath)
+    if m:
+        return (m.group(1), [(m.group(2), None)]) # requesting an attribute to exist
+
+    return (xpath, None)
+
+def check_or_make_target(module, tree, xpath, namespaces):
+    changed = False
+
+    (inner_xpath, changes) = split_xpath_last(xpath)
+    if not is_node(tree, inner_xpath, namespaces):
+        changed = check_or_make_target(module, tree, inner_xpath, namespaces)
+
+    if is_node(tree, inner_xpath, namespaces) and changes: # we test again after calling check_or_make_target
+        for (eoa, eoa_value) in changes:
+            if eoa[0] != '@' and (eoa_value is None):
+                # implicitly creating an element
+                new_kids = children_to_nodes(module, [eoa], "yaml")
+                for node in tree.xpath(inner_xpath, namespaces=namespaces):
+                    if not module.check_mode: node.extend(new_kids)
+                    changed = True
+                #abort(module, "now tree=" + etree.tostring(tree, pretty_print=True))
+            else:
+                abort(module, "NTO changed tree=" + etree.tostring(tree, pretty_print=True))
+    return changed
+
+
+def ensure_xpath_exists(module, tree, xpath, namespaces):
+    changed = False
+    
+    if not is_node(tree, xpath, namespaces):
+        changed = check_or_make_target(module, tree, xpath, namespaces)
+
+    finish(module, tree, xpath, namespaces, changed)
+
+def set_target_inner(module, tree, xpath, namespaces, attribute, value):
     changed = False
 
     if not is_node(tree, xpath, namespaces):
-        abort(module, "Xpath " + xpath + " does not reference a node!")
+        changed = check_or_make_target(module, tree, xpath, namespaces)
+
+    if not is_node(tree, xpath, namespaces):
+        abort(module, "Xpath " + xpath + " does not reference a node! tree is " + str(tree))
 
     for element in tree.xpath(xpath, namespaces=namespaces):
         if not attribute:
@@ -242,6 +289,10 @@ def set_target(module, tree, xpath, namespaces, attribute, value):
                 attribute = "{{{0}}}{1}".format(namespaces[attr_ns], attr_name)
             if not module.check_mode and (element.get(attribute) != value): element.set(attribute, value)
 
+    return changed
+
+def set_target(module, tree, xpath, namespaces, attribute, value):
+    changed = set_target_inner(module, tree, xpath, namespaces, attribute, value)
     finish(module, tree, xpath, namespaces, changed)
 
 def pretty(module, tree):
@@ -487,7 +538,8 @@ def main():
     if module.params['pretty_print']:
         pretty(module, x)
 
-    abort(module, "don't know what to do")
+    ensure_xpath_exists(module, x, xpath, namespaces)
+    #abort(module, "don't know what to do")
 
 ######################################################################
 from ansible.module_utils.basic import *

--- a/library/xml
+++ b/library/xml
@@ -119,8 +119,7 @@ try:
 except:
     import simplejson as json
 import lxml
-import os
-import re
+import sys, os, re
 
 def print_match(module, tree, xpath, namespaces):
     match = tree.xpath(xpath, namespaces=namespaces)
@@ -357,8 +356,11 @@ def ensure_xpath_exists(module, tree, xpath, namespaces):
 def set_target_inner(module, tree, xpath, namespaces, attribute, value):
     changed = False
 
-    if not is_node(tree, xpath, namespaces):
-        changed = check_or_make_target(module, tree, xpath, namespaces)
+    try:
+        if not is_node(tree, xpath, namespaces):
+            changed = check_or_make_target(module, tree, xpath, namespaces)
+    except Exception, e:
+        abort(module, "Xpath " + xpath + " causes a failure: "+str(e)+"  -- tree is " + etree.tostring(tree, pretty_print=True))
 
     if not is_node(tree, xpath, namespaces):
         abort(module, "Xpath " + xpath + " does not reference a node! tree is " + etree.tostring(tree, pretty_print=True))

--- a/library/xml
+++ b/library/xml
@@ -119,7 +119,7 @@ try:
 except:
     import simplejson as json
 import lxml
-import sys, os, re
+import sys, os, re, traceback
 
 def print_match(module, tree, xpath, namespaces):
     match = tree.xpath(xpath, namespaces=namespaces)
@@ -274,6 +274,14 @@ def split_xpath_last(xpath):
         return (m.group(1), [("", _extract_xpstr(m.group(2)))]) # requesting a change of inner text
     return (xpath, [])
 
+def nsnameToClark(name, namespaces):
+    if ":" in name:
+        (nsname, rawname) = name.split(":")
+        return "{{{0}}}{1}".format(namespaces[nsname], rawname)
+    else:
+        # no namespace name here
+        return name
+
 def check_or_make_target(module, tree, xpath, namespaces):
     (inner_xpath, changes) = split_xpath_last(xpath)
     if (inner_xpath == xpath) or (changes == None):
@@ -289,7 +297,7 @@ def check_or_make_target(module, tree, xpath, namespaces):
         for (eoa, eoa_value) in changes:
             if eoa and eoa[0] != '@' and eoa[0] != '/':
                 # implicitly creating an element
-                new_kids = children_to_nodes(module, [eoa], "yaml")
+                new_kids = children_to_nodes(module, [nsnameToClark(eoa, namespaces)], "yaml")
                 if eoa_value:
                     for nk in new_kids:
                         nk.text = eoa_value
@@ -300,7 +308,7 @@ def check_or_make_target(module, tree, xpath, namespaces):
                 #abort(module, "now tree=" + etree.tostring(tree, pretty_print=True))
             elif eoa and eoa[0] == '/':
                 element = eoa[1:]
-                new_kids = children_to_nodes(module, [element], "yaml")
+                new_kids = children_to_nodes(module, [nsnameToClark(element, namespaces)], "yaml")
 
                 for node in tree.xpath(inner_xpath, namespaces=namespaces):
                     if not module.check_mode: node.extend(new_kids)
@@ -319,11 +327,7 @@ def check_or_make_target(module, tree, xpath, namespaces):
                         changed = True
 
             elif eoa and eoa[0] == '@':
-                attribute = eoa[1:]
-
-                if ":" in attribute:
-                    attr_ns, attr_name = attribute.split(":")
-                    attribute = "{{{0}}}{1}".format(namespaces[attr_ns], attr_name)
+                attribute = nsnameToClark(eoa[1:], namespaces)
 
                 for element in tree.xpath(inner_xpath, namespaces=namespaces):
                     changing = (not element.attrib.has_key(attribute)) or (element.attrib.get(attribute) != eoa_value)
@@ -340,7 +344,7 @@ def check_or_make_target(module, tree, xpath, namespaces):
 
 
             else:
-                abort(module, "NTO changed tree=" + etree.tostring(tree, pretty_print=True))
+                abort(module, "unknown tree transformation=" + etree.tostring(tree, pretty_print=True))
 
     return changed
 
@@ -360,7 +364,7 @@ def set_target_inner(module, tree, xpath, namespaces, attribute, value):
         if not is_node(tree, xpath, namespaces):
             changed = check_or_make_target(module, tree, xpath, namespaces)
     except Exception, e:
-        abort(module, "Xpath " + xpath + " causes a failure: "+str(e)+"  -- tree is " + etree.tostring(tree, pretty_print=True))
+        abort(module, "Xpath " + xpath + " causes a failure: "+str(e)+ "\n" + traceback.format_exc(e)+"\n  -- tree is " + etree.tostring(tree, pretty_print=True))
 
     if not is_node(tree, xpath, namespaces):
         abort(module, "Xpath " + xpath + " does not reference a node! tree is " + etree.tostring(tree, pretty_print=True))

--- a/library/xml
+++ b/library/xml
@@ -232,18 +232,47 @@ def add_target_children(module, tree, xpath, namespaces, children, type):
 
 _ident = "[a-zA-Z-][a-zA-Z0-9_-]*"
 _nsIdent = _ident +"|"+_ident+":"+_ident
+_xpstr = "('(?:.*)'|\"(?:.*)\")" # Note: we can't reasonably support the 'if you need to put both ' and " in a string, concatenate
+                               # strings wrapped by the other delimiter' XPath trick, especially as simple XPath.
+
 _re_splitSimpleLast = re.compile("^(.*)/("+_nsIdent+")$")
+_re_splitSimpleLastEqValue = re.compile("^(.*)/("+_nsIdent+")/text\\(\\)="+_xpstr+"$")
 _re_splitSimpleAttrLast = re.compile("^(.*)/(@(?:"+_nsIdent+"))$")
+_re_splitSimpleAttrLastEqValue = re.compile("^(.*)/(@(?:"+_nsIdent+"))="+_xpstr+"$")
+
+_re_splitSubLast = re.compile("^(.*)/("+_nsIdent+")\\[(.*)\\]$")
+
+_re_splitOnlyEqValue = re.compile("^(.*)/text\\(\\)="+_xpstr+"$")
+
+def _extract_xpstr(g):
+    return g[1:-1]
+
 def split_xpath_last(xpath):
     """split an XPath of the form /foo/bar/baz into /foo/bar and baz"""
     xpath = xpath.strip()
     m = _re_splitSimpleLast.match(xpath)
     if m:
-        return (m.group(1), [(m.group(2), None)]) # requesting an attribute to exist
+        return (m.group(1), [(m.group(2), None)]) # requesting an element to exist
+    m = _re_splitSimpleLastEqValue.match(xpath)
+    if m:
+        return (m.group(1), [(m.group(2), _extract_xpstr(m.group(3)))]) # requesting an element to exist with an inner text
+
     m = _re_splitSimpleAttrLast.match(xpath)
     if m:
         return (m.group(1), [(m.group(2), None)]) # requesting an attribute to exist
+    m = _re_splitSimpleAttrLastEqValue.match(xpath)
+    if m:
+        return (m.group(1), [(m.group(2), _extract_xpstr(m.group(3)))]) # requesting an attribute to exist with a value
 
+    m = _re_splitSubLast.match(xpath)
+    if m:
+        content = map(lambda x: x.strip(), m.group(3).split(" and "))
+
+        return (m.group(1),  [('/'+m.group(2), content )] )
+
+    m = _re_splitOnlyEqValue.match(xpath)
+    if m:
+        return (m.group(1), [("", _extract_xpstr(m.group(2)))]) # requesting a change of inner text
     return (xpath, [])
 
 def check_or_make_target(module, tree, xpath, namespaces):
@@ -259,14 +288,38 @@ def check_or_make_target(module, tree, xpath, namespaces):
 
     if is_node(tree, inner_xpath, namespaces) and changes: # we test again after calling check_or_make_target
         for (eoa, eoa_value) in changes:
-            if eoa[0] != '@' and (eoa_value is None):
+            if eoa and eoa[0] != '@' and eoa[0] != '/':
                 # implicitly creating an element
                 new_kids = children_to_nodes(module, [eoa], "yaml")
+                if eoa_value:
+                    for nk in new_kids:
+                        nk.text = eoa_value
+
                 for node in tree.xpath(inner_xpath, namespaces=namespaces):
                     if not module.check_mode: node.extend(new_kids)
                     changed = True
                 #abort(module, "now tree=" + etree.tostring(tree, pretty_print=True))
-            elif eoa[0] == '@':
+            elif eoa and eoa[0] == '/':
+                element = eoa[1:]
+                new_kids = children_to_nodes(module, [element], "yaml")
+
+                for node in tree.xpath(inner_xpath, namespaces=namespaces):
+                    if not module.check_mode: node.extend(new_kids)
+                    for nk in new_kids:
+                        for subexpr in eoa_value:
+                            #abort(module, "element="+element+" subexpr="+str(subexpr)+" node="+etree.tostring(node, pretty_print=True)+
+                            #    " now tree=" + etree.tostring(tree, pretty_print=True))
+                            check_or_make_target(module, nk, "./"+subexpr, namespaces)
+                    changed = True
+
+                #abort(module, "now tree=" + etree.tostring(tree, pretty_print=True))
+            elif eoa == "":
+                for node in tree.xpath(inner_xpath, namespaces=namespaces):
+                    if (node.text != eoa_value):
+                        node.text = eoa_value
+                        changed = True
+
+            elif eoa and eoa[0] == '@':
                 attribute = eoa[1:]
 
                 if ":" in attribute:

--- a/tests/.gitignore
+++ b/tests/.gitignore
@@ -1,0 +1,1 @@
+test.retry

--- a/tests/results/test-add-element-implicitly.yml
+++ b/tests/results/test-add-element-implicitly.yml
@@ -19,6 +19,7 @@
     <name>
       <last>Smith</last>
       <first>John</first>
+      <middle>Q</middle>
     </name>
   </owner>
   <website_bis>

--- a/tests/results/test-add-element-implicitly.yml
+++ b/tests/results/test-add-element-implicitly.yml
@@ -1,0 +1,27 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<business type="bar">
+  <name>Tasty Beverage Co.</name>
+  <beers>
+    <beer>Rochefort 10</beer>
+    <beer>St. Bernardus Abbot 12</beer>
+    <beer>Schlitz</beer>
+    <beer color="red">George Killian's Irish Red</beer>
+    <beer origin="CZ" color="blonde">Pilsner Urquell</beer>
+  </beers>
+  <rating subjective="true">10</rating>
+  <website>
+    <mobilefriendly/>
+    <address>http://tastybeverageco.com</address>
+    <validxhtml validateon=""/>
+  </website>
+  <phonenumber>555-555-1234</phonenumber>
+  <owner dob="1976-04-12">
+    <name>
+      <last>Smith</last>
+      <first>John</first>
+    </name>
+  </owner>
+  <website_bis>
+    <validxhtml validateon=""/>
+  </website_bis>
+</business>

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -1,0 +1,7 @@
+---
+- name: Setup test fixture
+  copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+
+- name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
+  xml: file=/tmp/ansible-xml-beers.xml xpath=/business/phonenumber value=555-555-1234
+  

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -1,7 +1,16 @@
 ---
 - name: Setup test fixture
-  copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers.xml
+  copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers-implicit.xml
 
 - name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
-  xml: file=/tmp/ansible-xml-beers.xml xpath=/business/phonenumber value=555-555-1234
-  
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/phonenumber value=555-555-1234
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 1/2
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name/last value=Smith
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name/first value=John
+
+
+- name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml ensure=present

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -33,6 +33,9 @@
 - name: Add two attributes on a conditional element
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"Pilsner Urquell\" and @origin='CZ']/@color='blonde'"
 
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 3/2 -- complex lookup
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name[first/text()='John']/middle value=Q
+
 - name: Pretty Print this!
   xml: file=/tmp/ansible-xml-beers-implicit.xml pretty_print=True
 

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -31,4 +31,10 @@
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"George Killian's Irish Red\"]/@color='red'"
 
 - name: Add two attributes on a conditional element
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"Pilsner Urquell\" and @origin='CZ']/@color='blonde'" 
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"Pilsner Urquell\" and @origin='CZ']/@color='blonde'"
+
+- name: Pretty Print this!
+  xml: file=/tmp/ansible-xml-beers-implicit.xml pretty_print=True
+
+- name: Test expected result
+  command: diff -u results/test-add-element-implicitly.yml /tmp/ansible-xml-beers-implicit.xml

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -11,6 +11,12 @@
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name/first value=John
 
-
 - name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml ensure=present
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml
+
+
+- name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml/@validateon
+
+- name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website_bis/validxhtml/@validateon

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -41,3 +41,91 @@
 
 - name: Test expected result
   command: diff -u results/test-add-element-implicitly.yml /tmp/ansible-xml-beers-implicit.xml
+
+#
+# Now we repeat the same, just to ensure proper use of namespaces
+#
+
+- name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:phonenumber
+    value: 555-555-1234
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 1/2
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/a:name/a:last
+    value: Smith
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/a:name/a:first
+    value: John
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:website/a:validxhtml
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:website/a:validxhtml/@a:validateon
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:website_bis/a:validxhtml/@a:validateon
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an attribute with a value
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/@a:dob='1976-04-12'
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an element with a value, alternate syntax
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: "/business/a:beers/a:beer/text()=\"George Killian's Irish Red\"" # note the quote within an XPath string thing
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add an attribute on a conditional element
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: "/business/a:beers/a:beer[text()=\"George Killian's Irish Red\"]/@a:color='red'"
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add two attributes on a conditional element
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: "/business/a:beers/a:beer[text()=\"Pilsner Urquell\" and @a:origin='CZ']/@a:color='blonde'"
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Add a owner element to the business element, testing implicit mkdir -p behavior 3/2 -- complex lookup
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:owner/a:name[a:first/text()='John']/a:middle
+    value: Q
+    namespaces:
+      a: http://example.com/some/namespace
+
+- name: Pretty Print this!
+  xml: file=/tmp/ansible-xml-beers-implicit.xml pretty_print=True

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -14,9 +14,21 @@
 - name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml
 
-
 - name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml/@validateon
 
 - name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website_bis/validxhtml/@validateon
+
+- name: Add an attribute with a value
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/@dob='1976-04-12'
+
+- name: Add an element with a value, alternate syntax
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer/text()=\"George Killian's Irish Red\"" # note the quote within an XPath string thing
+
+
+- name: Add an attribute on a conditional element
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"George Killian's Irish Red\"]/@color='red'"
+
+- name: Add two attributes on a conditional element
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"Pilsner Urquell\" and @origin='CZ']/@color='blonde'" 

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,34 +8,34 @@
 
   tasks:
     - include: test-add-children-elements.yml
-    - include: test-add-children-from-groupvars.yml
-    - include: test-add-children-with-attributes.yml
+#    - include: test-add-children-from-groupvars.yml
+#    - include: test-add-children-with-attributes.yml
     - include: test-add-element-implicitly.yml
-    - include: test-count.yml
-    - include: test-mutually-exclusive-attributes.yml
-    - include: test-remove-attribute.yml
-    - include: test-remove-element.yml
-    - include: test-set-attribute-value.yml
-    - include: test-set-children-elements.yml
-    - include: test-set-children-elements-level.yml
-    - include: test-set-element-value.yml
-    - include: test-set-element-value-empty.yml
-    - include: test-pretty-print.yml
-    - include: test-pretty-print-only.yml
-    - include: test-add-namespaced-children-elements.yml
-    - include: test-remove-namespaced-attribute.yml
-    - include: test-set-namespaced-attribute-value.yml
-    - include: test-set-namespaced-element-value.yml
-    - include: test-get-element-content.yml
-    - include: test-xmlstring.yml
-    - include: test-children-elements-xml.yml
+#    - include: test-count.yml
+#    - include: test-mutually-exclusive-attributes.yml
+#    - include: test-remove-attribute.yml
+#    - include: test-remove-element.yml
+#    - include: test-set-attribute-value.yml
+#    - include: test-set-children-elements.yml
+#    - include: test-set-children-elements-level.yml
+#    - include: test-set-element-value.yml
+#    - include: test-set-element-value-empty.yml
+#    - include: test-pretty-print.yml
+#    - include: test-pretty-print-only.yml
+#    - include: test-add-namespaced-children-elements.yml
+#    - include: test-remove-namespaced-attribute.yml
+#    - include: test-set-namespaced-attribute-value.yml
+#    - include: test-set-namespaced-element-value.yml
+#    - include: test-get-element-content.yml
+#    - include: test-xmlstring.yml
+#    - include: test-children-elements-xml.yml
 
     # Unicode tests
-    - include: test-add-children-elements-unicode.yml
-    - include: test-add-children-with-attributes-unicode.yml
-    - include: test-set-attribute-value-unicode.yml
-    - include: test-count-unicode.yml
-    - include: test-get-element-content.yml
-    - include: test-set-children-elements-unicode.yml
-    - include: test-set-element-value-unicode.yml
+#    - include: test-add-children-elements-unicode.yml
+#    - include: test-add-children-with-attributes-unicode.yml
+#    - include: test-set-attribute-value-unicode.yml
+#    - include: test-count-unicode.yml
+#    - include: test-get-element-content.yml
+#    - include: test-set-children-elements-unicode.yml
+#    - include: test-set-element-value-unicode.yml
 ...

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -10,6 +10,7 @@
     - include: test-add-children-elements.yml
     - include: test-add-children-from-groupvars.yml
     - include: test-add-children-with-attributes.yml
+    - include: test-add-element-implicitly.yml
     - include: test-count.yml
     - include: test-mutually-exclusive-attributes.yml
     - include: test-remove-attribute.yml

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -8,34 +8,34 @@
 
   tasks:
     - include: test-add-children-elements.yml
-#    - include: test-add-children-from-groupvars.yml
-#    - include: test-add-children-with-attributes.yml
+    - include: test-add-children-from-groupvars.yml
+    - include: test-add-children-with-attributes.yml
     - include: test-add-element-implicitly.yml
-#    - include: test-count.yml
-#    - include: test-mutually-exclusive-attributes.yml
-#    - include: test-remove-attribute.yml
-#    - include: test-remove-element.yml
-#    - include: test-set-attribute-value.yml
-#    - include: test-set-children-elements.yml
-#    - include: test-set-children-elements-level.yml
-#    - include: test-set-element-value.yml
-#    - include: test-set-element-value-empty.yml
-#    - include: test-pretty-print.yml
-#    - include: test-pretty-print-only.yml
-#    - include: test-add-namespaced-children-elements.yml
-#    - include: test-remove-namespaced-attribute.yml
-#    - include: test-set-namespaced-attribute-value.yml
-#    - include: test-set-namespaced-element-value.yml
-#    - include: test-get-element-content.yml
-#    - include: test-xmlstring.yml
-#    - include: test-children-elements-xml.yml
+    - include: test-count.yml
+    - include: test-mutually-exclusive-attributes.yml
+    - include: test-remove-attribute.yml
+    - include: test-remove-element.yml
+    - include: test-set-attribute-value.yml
+    - include: test-set-children-elements.yml
+    - include: test-set-children-elements-level.yml
+    - include: test-set-element-value.yml
+    - include: test-set-element-value-empty.yml
+    - include: test-pretty-print.yml
+    - include: test-pretty-print-only.yml
+    - include: test-add-namespaced-children-elements.yml
+    - include: test-remove-namespaced-attribute.yml
+    - include: test-set-namespaced-attribute-value.yml
+    - include: test-set-namespaced-element-value.yml
+    - include: test-get-element-content.yml
+    - include: test-xmlstring.yml
+    - include: test-children-elements-xml.yml
 
     # Unicode tests
-#    - include: test-add-children-elements-unicode.yml
-#    - include: test-add-children-with-attributes-unicode.yml
-#    - include: test-set-attribute-value-unicode.yml
-#    - include: test-count-unicode.yml
-#    - include: test-get-element-content.yml
-#    - include: test-set-children-elements-unicode.yml
-#    - include: test-set-element-value-unicode.yml
+    - include: test-add-children-elements-unicode.yml
+    - include: test-add-children-with-attributes-unicode.yml
+    - include: test-set-attribute-value-unicode.yml
+    - include: test-count-unicode.yml
+    - include: test-get-element-content.yml
+    - include: test-set-children-elements-unicode.yml
+    - include: test-set-element-value-unicode.yml
 ...


### PR DESCRIPTION
As remarked in #81 and #37, attempting to follow the README actually fails with an "XPath does not reference a node!" error message.

This PR adds a **limited** support for that (covering all the cases mentioned by the README + a few others)

the new file tests/test-add-element-implicitly.yml tests all supported manipulation cases