### PR TITLE
Add option to prevent CDATA strip

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -106,6 +106,12 @@ options:
     choices:
       - "yaml"
       - "xml"
+  strip_tags:
+    description:
+      - "Remove CDATA tags from XML"
+    required: false
+    default: true
+    choices: []
 requirements:
     - The remote end must have the Python C(lxml) library installed
 author: Tim Bielawa, Magnus Hedemark
@@ -382,7 +388,8 @@ def main():
             print_match=dict(required=False, default=None, type='bool'),
             pretty_print=dict(required=False, default=False, type='bool'),
             content=dict(required=False, default=None, choices=['attribute', 'text']),
-            input_type=dict(required=False, default='yaml', choices=['yaml', 'xml'])
+            input_type=dict(required=False, default='yaml', choices=['yaml', 'xml']),
+            strip_tags=dict(required=False, default=True, type='bool')
         ),
         supports_check_mode=True,
         mutually_exclusive = [
@@ -408,6 +415,7 @@ def main():
     pretty_print = module.params['pretty_print']
     content = module.params['content']
     input_type = module.params['input_type']
+    strip_tags = module.params['strip_tags']
 
     ##################################################################
     # Check if the file exists
@@ -423,7 +431,7 @@ def main():
 
     # Try to parse in the target XML file
     try:
-        parser = etree.XMLParser(remove_blank_text=pretty_print)
+        parser = etree.XMLParser(remove_blank_text=pretty_print,strip_cdata=strip_tags)
         x = etree.parse(infile, parser)
     except etree.XMLSyntaxError, e:
         module.fail_json(


### PR DESCRIPTION
This adds boolean option strip_tags that would prevent CDATA tags to be stripped.
Also making the module more in line with Ansible mindset of not changing what doesn't need changing.