### PR TITLE
xml: Add dot in regex for implicit nodes

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -230,7 +230,7 @@ def add_target_children(module, tree, xpath, namespaces, children, type):
     else:
         finish(module, tree, xpath, namespaces)
 
-_ident = "[a-zA-Z-][a-zA-Z0-9_-]*"
+_ident = "[a-zA-Z-][a-zA-Z0-9_\-\.]*"
 _nsIdent = _ident +"|"+_ident+":"+_ident
 _xpstr = "('(?:.*)'|\"(?:.*)\")" # Note: we can't reasonably support the 'if you need to put both ' and " in a string, concatenate
                                # strings wrapped by the other delimiter' XPath trick, especially as simple XPath.
@@ -310,7 +310,6 @@ def check_or_make_target(module, tree, xpath, namespaces):
             elif eoa and eoa[0] == '/':
                 element = eoa[1:]
                 new_kids = children_to_nodes(module, [nsnameToClark(element, namespaces)], "yaml")
-
                 for node in tree.xpath(inner_xpath, namespaces=namespaces):
                     if not module.check_mode: node.extend(new_kids)
                     for nk in new_kids:

--- a/tests/results/test-add-element-implicitly.yml
+++ b/tests/results/test-add-element-implicitly.yml
@@ -25,4 +25,8 @@
   <website_bis>
     <validxhtml validateon=""/>
   </website_bis>
+  <testnormalelement>xml tag with no special characters</testnormalelement>
+  <test-with-dash>xml tag with dashes</test-with-dash>
+  <test-with-dash.and.dot>xml tag with dashes and dots</test-with-dash.and.dot>
+  <test-with.dash_and.dot_and-underscores>xml tag with dashes, dots and underscores</test-with.dash_and.dot_and-underscores>
 </business>

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -26,6 +26,17 @@
 - name: Add an element with a value, alternate syntax
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer/text()=\"George Killian's Irish Red\"" # note the quote within an XPath string thing
 
+- name: Add an element without special characters
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/testnormalelement value="xml tag with no special characters" pretty_print=true
+
+- name: Add an element with dash
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/test-with-dash value="xml tag with dashes" pretty_print=true
+
+- name: Add an element with dot
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/test-with-dash.and.dot value="xml tag with dashes and dots" pretty_print=true
+
+- name: Add an element with underscore
+  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/test-with.dash_and.dot_and-underscores value="xml tag with dashes, dots and underscores" pretty_print=true
 
 - name: Add an attribute on a conditional element
   xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"George Killian's Irish Red\"]/@color='red'"
@@ -126,6 +137,43 @@
     value: Q
     namespaces:
       a: http://example.com/some/namespace
+
+- name: Add an element without special characters
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/testnormalelement
+    value: "xml tag with no special characters"
+    pretty_print: true
+    namespaces:
+      a:  http://example.com/some/namespace
+
+
+- name: Add an element with dash
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash
+    value: "xml tag with dashes"
+    pretty_print: true
+    namespaces:
+      a:  http://example.com/some/namespace
+
+- name: Add an element with dot
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash.and.dot
+    value: "xml tag with dashes and dots"
+    pretty_print: true
+    namespaces:
+      a:  http://example.com/some/namespace
+
+- name: Add an element with underscore
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with.dash_and.dot_and-underscores
+    value: "xml tag with dashes, dots and underscores"
+    pretty_print: true
+    namespaces:
+      a:  http://example.com/some/namespace
 
 - name: Pretty Print this!
   xml: file=/tmp/ansible-xml-beers-implicit.xml pretty_print=True


### PR DESCRIPTION
Lots of xml tags contains dots (ex: xml files in jenkins). Adding an
element in those tags fail with the error:
  Can't process Xpath [...] in order to spawn nodes!
This commit adds the dot in the regex to be able to handle these tags.