### PR TITLE
Guard main()

### DIFF
--- a/library/xml
+++ b/library/xml
@@ -635,4 +635,6 @@ def main():
 
 ######################################################################
 from ansible.module_utils.basic import *
-main()
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
This makes sure we don't confuse e.g. nosetest when pulled into other
projects.