### PR TITLE
Fix remaining issues with test examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ Remove the ``subjective`` attribute of the rating element:
 xml:
   path: /foo/bar.xml
   xpath: /business/rating/@subjective
-  ensure: absent
+  state: absent
 ```
 
 Set the rating to **11**
@@ -84,7 +84,7 @@ Get count of beers nodes
 xml:
   path: /foo/bar.xml
   xpath: /business/beers/beer
-  count: true
+  count: yes
 register: hits
 
 debug:
@@ -135,7 +135,7 @@ xml:
 ```
 
 Add a ``validxhtml`` element to the ``website`` element. Note that
-``ensure`` is ``present`` by default, and ``value`` defaults to
+``state`` is ``present`` by default, and ``value`` defaults to
 ``null`` for elements. The result is something like
 ``<website><validxhtml />...</website>``
 
@@ -162,7 +162,7 @@ xml:
 xml:
   path: /foo/bar.xml
   xpath: /business/website/*
-  ensure: absent
+  state: absent
 ```
 
 (2/2) Remove all children from the website element:
@@ -180,7 +180,7 @@ What happens if you say:
 
 ```yaml
 xml:
-  file: /foo/bar.xml
+  path: /foo/bar.xml
   xpath: /beers
 ```
 

--- a/tests/test-add-element-implicitly.yml
+++ b/tests/test-add-element-implicitly.yml
@@ -1,54 +1,101 @@
 ---
 - name: Setup test fixture
-  copy: src=fixtures/ansible-xml-beers.xml dest=/tmp/ansible-xml-beers-implicit.xml
+  copy:
+    src: fixtures/ansible-xml-beers.xml
+    dest: /tmp/ansible-xml-beers-implicit.xml
 
 - name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/phonenumber value=555-555-1234
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/phonenumber
+    value: 555-555-1234
 
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 1/2
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name/last value=Smith
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/name/last
+    value: Smith
 
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name/first value=John
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/name/first
+    value: John
 
 - name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/website/validxhtml
 
 - name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website/validxhtml/@validateon
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/website/validxhtml/@validateon
 
 - name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/website_bis/validxhtml/@validateon
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/website_bis/validxhtml/@validateon
 
 - name: Add an attribute with a value
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/@dob='1976-04-12'
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/@dob='1976-04-12'
 
 - name: Add an element with a value, alternate syntax
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer/text()=\"George Killian's Irish Red\"" # note the quote within an XPath string thing
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    # note the quote within an XPath string thing
+    xpath: /business/beers/beer/text()="George Killian's Irish Red"
 
 - name: Add an element without special characters
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/testnormalelement value="xml tag with no special characters" pretty_print=true
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/testnormalelement
+    value: xml tag with no special characters
+    pretty_print: yes
 
 - name: Add an element with dash
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/test-with-dash value="xml tag with dashes" pretty_print=true
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash
+    value: xml tag with dashes
+    pretty_print: yes
 
 - name: Add an element with dot
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/test-with-dash.and.dot value="xml tag with dashes and dots" pretty_print=true
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with-dash.and.dot
+    value: xml tag with dashes and dots
+    pretty_print: yes
 
 - name: Add an element with underscore
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/test-with.dash_and.dot_and-underscores value="xml tag with dashes, dots and underscores" pretty_print=true
+  xml:
+    file: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/test-with.dash_and.dot_and-underscores
+    value: xml tag with dashes, dots and underscores
+    pretty_print: yes
 
 - name: Add an attribute on a conditional element
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"George Killian's Irish Red\"]/@color='red'"
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/beers/beer[text()="George Killian's Irish Red"]/@color='red'
 
 - name: Add two attributes on a conditional element
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath="/business/beers/beer[text()=\"Pilsner Urquell\" and @origin='CZ']/@color='blonde'"
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/beers/beer[text()="Pilsner Urquell" and @origin='CZ']/@color='blonde'
 
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 3/2 -- complex lookup
-  xml: file=/tmp/ansible-xml-beers-implicit.xml xpath=/business/owner/name[first/text()='John']/middle value=Q
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/owner/name[first/text()='John']/middle
+    value: Q
 
 - name: Pretty Print this!
-  xml: file=/tmp/ansible-xml-beers-implicit.xml pretty_print=True
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    pretty_print: yes
 
 - name: Test expected result
   command: diff -u results/test-add-element-implicitly.yml /tmp/ansible-xml-beers-implicit.xml
@@ -59,7 +106,7 @@
 
 - name: Add a phonenumber element to the business element. Implicit mkdir -p behavior where applicable
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:phonenumber
     value: 555-555-1234
     namespaces:
@@ -67,7 +114,7 @@
 
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 1/2
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:owner/a:name/a:last
     value: Smith
     namespaces:
@@ -75,7 +122,7 @@
 
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 2/2
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:owner/a:name/a:first
     value: John
     namespaces:
@@ -83,56 +130,56 @@
 
 - name: Add a validxhtml element to the website element. Note that ensure is present by default and while value defaults to null for elements, if one doesn't specify it we don't know what to do.
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:website/a:validxhtml
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add an empty validateon attribute to the validxhtml element. This actually makes the previous example redundant because of the implicit parent-node creation behavior.
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:website/a:validxhtml/@a:validateon
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add an empty validateon attribute to the validxhtml element. Actually verifies the implicit parent-node creation behavior.
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:website_bis/a:validxhtml/@a:validateon
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add an attribute with a value
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:owner/@a:dob='1976-04-12'
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add an element with a value, alternate syntax
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
-    xpath: "/business/a:beers/a:beer/text()=\"George Killian's Irish Red\"" # note the quote within an XPath string thing
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:beers/a:beer/text()="George Killian's Irish Red" # note the quote within an XPath string thing
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add an attribute on a conditional element
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
-    xpath: "/business/a:beers/a:beer[text()=\"George Killian's Irish Red\"]/@a:color='red'"
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:beers/a:beer[text()="George Killian's Irish Red"]/@a:color='red'
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add two attributes on a conditional element
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
-    xpath: "/business/a:beers/a:beer[text()=\"Pilsner Urquell\" and @a:origin='CZ']/@a:color='blonde'"
+    path: /tmp/ansible-xml-beers-implicit.xml
+    xpath: /business/a:beers/a:beer[text()="Pilsner Urquell" and @a:origin='CZ']/@a:color='blonde'
     namespaces:
       a: http://example.com/some/namespace
 
 - name: Add a owner element to the business element, testing implicit mkdir -p behavior 3/2 -- complex lookup
   xml:
-    file: /tmp/ansible-xml-beers-implicit.xml
+    path: /tmp/ansible-xml-beers-implicit.xml
     xpath: /business/a:owner/a:name[a:first/text()='John']/a:middle
     value: Q
     namespaces:
@@ -176,4 +223,6 @@
       a:  http://example.com/some/namespace
 
 - name: Pretty Print this!
-  xml: file=/tmp/ansible-xml-beers-implicit.xml pretty_print=True
+  xml:
+    path: /tmp/ansible-xml-beers-implicit.xml
+    pretty_print: yes

--- a/tests/test-count-unicode.yml
+++ b/tests/test-count-unicode.yml
@@ -8,6 +8,6 @@
     xml:
       path: /tmp/ansible-xml-beers-unicode.xml
       xpath: /business/beers/beer
-      count: true
+      count: yes
     register: beers
     failed_when: beers.count != 2

--- a/tests/test-count.yml
+++ b/tests/test-count.yml
@@ -8,6 +8,6 @@
     xml:
       path: /tmp/ansible-xml-beers.xml
       xpath: /business/beers/beer
-      count: true
+      count: yes
     register: beers
     failed_when: beers.count != 3

--- a/tests/test-mutually-exclusive-attributes.yml
+++ b/tests/test-mutually-exclusive-attributes.yml
@@ -12,4 +12,4 @@
             - child02
         value: conflict!
     register: module_output
-    failed_when: "module_output.failed == 'false'"
+    failed_when: module_output.failed == 'false'

--- a/tests/test-pretty-print-only.yml
+++ b/tests/test-pretty-print-only.yml
@@ -1,11 +1,11 @@
 ---
   - name: Setup test fixture
-    shell: cat fixtures/ansible-xml-beers.xml | sed 's/^[ ]*//g' > /tmp/ansible-xml-beers.xml
+    shell: sed 's/^[ ]*//g' <fixtures/ansible-xml-beers.xml >/tmp/ansible-xml-beers.xml
 
   - name: Pretty print without modification
     xml:
       path: /tmp/ansible-xml-beers.xml
-      pretty_print: True
+      pretty_print: yes
 
   - name: Test expected result
     command: diff results/test-pretty-print-only.xml /tmp/ansible-xml-beers.xml

--- a/tests/test-pretty-print.yml
+++ b/tests/test-pretty-print.yml
@@ -8,7 +8,7 @@
     xml:
       path: /tmp/ansible-xml-beers.xml
       xpath: /business/beers
-      pretty_print: True
+      pretty_print: yes
       add_children:
         - beer: "Old Rasputin"
 

--- a/tests/test-remove-attribute.yml
+++ b/tests/test-remove-attribute.yml
@@ -8,7 +8,7 @@
     xml:
       path: /tmp/ansible-xml-beers.xml
       xpath: /business/rating/@subjective
-      ensure: absent
+      state: absent
 
   - name: Test expected result
     command: diff results/test-remove-attribute.xml /tmp/ansible-xml-beers.xml

--- a/tests/test-remove-element.yml
+++ b/tests/test-remove-element.yml
@@ -8,7 +8,7 @@
     xml:
       path: /tmp/ansible-xml-beers.xml
       xpath: /business/rating
-      ensure: absent
+      state: absent
 
   - name: Test expected result
     command: diff results/test-remove-element.xml /tmp/ansible-xml-beers.xml

--- a/tests/test-remove-namespaced-attribute.yml
+++ b/tests/test-remove-namespaced-attribute.yml
@@ -13,7 +13,7 @@
         ber: http://test.beers
         rat: http://test.rating
         attr: http://test.attribute
-      ensure: absent
+      state: absent
 
   - name: Test expected result
     command: diff results/test-remove-namespaced-attribute.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/tests/test-remove-namespaced-element.yml
+++ b/tests/test-remove-namespaced-element.yml
@@ -13,7 +13,7 @@
         ber: http://test.beers
         rat: http://test.rating
         attr: http://test.attribute
-      ensure: absent
+      state: absent
 
   - name: Test expected result
     command: diff results/test-remove-element.xml /tmp/ansible-xml-namespaced-beers.xml

--- a/tests/test-set-attribute-value-unicode.yml
+++ b/tests/test-set-attribute-value-unicode.yml
@@ -13,4 +13,4 @@
 
   - name: Test expected result
     command: diff results/test-set-attribute-value-unicode.xml /tmp/ansible-xml-beers.xml
-    changed_when: False
+    changed_when: no

--- a/tests/test-set-attribute-value.yml
+++ b/tests/test-set-attribute-value.yml
@@ -13,4 +13,4 @@
 
   - name: Test expected result
     command: diff results/test-set-attribute-value.xml /tmp/ansible-xml-beers.xml
-    changed_when: False
+    changed_when: no

--- a/tests/test-set-element-value-unicode.yml
+++ b/tests/test-set-element-value-unicode.yml
@@ -27,7 +27,7 @@
 
   - name: Test expected result
     command: diff results/test-set-element-value-unicode.xml /tmp/ansible-xml-beers.xml
-    changed_when: False
+    changed_when: no
 
   - name: Test registered 'changed' on run 1 and unchanged on run 2
     assert:

--- a/tests/test-set-element-value.yml
+++ b/tests/test-set-element-value.yml
@@ -27,7 +27,7 @@
 
   - name: Test expected result
     command: diff results/test-set-element-value.xml /tmp/ansible-xml-beers.xml
-    changed_when: False
+    changed_when: no
 
   - name: Test registered 'changed' on run 1 and unchanged on run 2
     assert:

--- a/tests/test-set-namespaced-attribute-value.yml
+++ b/tests/test-set-namespaced-attribute-value.yml
@@ -18,4 +18,4 @@
 
   - name: Test expected result
     command: diff results/test-set-namespaced-attribute-value.xml /tmp/ansible-xml-namespaced-beers.xml
-    changed_when: False
+    changed_when: no

--- a/tests/test-set-namespaced-element-value.yml
+++ b/tests/test-set-namespaced-element-value.yml
@@ -30,7 +30,7 @@
 
   - name: Test expected result
     command: diff results/test-set-namespaced-element-value.xml /tmp/ansible-xml-namespaced-beers.xml
-    changed_when: False
+    changed_when: no
 
   - name: Test registered 'changed' on run 1 and unchanged on run 2
     assert:

--- a/tests/test-xmlstring.yml
+++ b/tests/test-xmlstring.yml
@@ -2,7 +2,7 @@
   - name: Read from xmlstring
     xml:
       xmlstring: "{{ lookup('file', 'fixtures/ansible-xml-beers.xml') }}"
-      pretty_print: True
+      pretty_print: yes
     register: xmlresponse
  
   - name: Write result to file
@@ -17,7 +17,7 @@
     xml:
       xmlstring: "{{ lookup('file', 'fixtures/ansible-xml-beers.xml') }}"
       xpath: /business/beers
-      pretty_print: True
+      pretty_print: yes
       add_children:
         - beer: "Old Rasputin"
     register: xmlresponse_modification


### PR DESCRIPTION
This PR includes:
- Replaced the "ensure" parameter with "state"
- Replaced the "file" parameter with "path"
- Use "yes" and "no" as booleans, instead of "true", "True", "false" and "False"
- Use YAML syntax everywhere
- Avoid the use of quotes when they are not needed

This fixes #106 
Relates to #52